### PR TITLE
Fix comment in SQL init script

### DIFF
--- a/scripts_honeypot/061_sql_init.sh
+++ b/scripts_honeypot/061_sql_init.sh
@@ -7,7 +7,7 @@ BASE_DIR="honeypot"
 # 1. Crear carpeta sql-init si no existe
 SQL_INIT_DIR="$BASE_DIR/sql-init"
 echo "==> Creando directorio $SQL_INIT_DIR..."
-mkdir -p "$SQL_INIT_DIR"                   # no da error si ya existe :contentReference[oaicite:5]{index=5}
+mkdir -p "$SQL_INIT_DIR"                   # no da error si ya existe
 
 # 2. Generar create_tables.sql con la definición de la tabla reservas
 INIT_SQL="$SQL_INIT_DIR/create_tables.sql"


### PR DESCRIPTION
## Summary
- clean up comment for creating SQL init directory

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684424c8c7d8832a8559a6e5cc3eb00f