### PR TITLE
Remove unused ModSecurity remnants

### DIFF
--- a/scripts_honeypot/02_gen_compose.sh
+++ b/scripts_honeypot/02_gen_compose.sh
@@ -36,7 +36,7 @@ services:
     ports: ["3306:3306"]
     networks: { dmz: { ipv4_address: 172.18.0.18 } }
 
-#─────────────────── Apache + ModSecurity ───
+#─────────────────── Apache ───
   apache:
     build: ./apache
     image: apache_custom
@@ -45,7 +45,6 @@ services:
     volumes:
       - ./web/:/var/www/html:ro
       - ./volumenes/apache_logs:/var/log/apache2            # access & error
-      - ./volumenes/modsec_logs:/var/log/modsecurity        # audit JSON
     ports: ["80:80"]
     networks: { dmz: { ipv4_address: 172.18.0.12 } }
 
@@ -90,8 +89,6 @@ services:
       - ./volumenes/mysql_log:/var/log/mysql:ro
       - ./volumenes/ftp_logs:/var/log/proftpd:ro
       - ./volumenes/fakessh_logs:/var/log/fakessh:ro
-      # log JSON de ModSecurity (ruta distinta para evitar solaparse)
-      - ./volumenes/modsec_logs:/var/log/modsecurity:ro
       # config & posiciones
       - ./config/promtail-config.yaml:/etc/promtail/config.yml:ro
       - promtail-data:/var/lib/promtail

--- a/scripts_honeypot/07_promtail.sh
+++ b/scripts_honeypot/07_promtail.sh
@@ -32,19 +32,6 @@ scrape_configs:
           expression: 'IP=(?P<remote_ip>\d+\.\d+\.\d+\.\d+).*usuario=\'(?P<user>[^\']+)\' contraseña=\'(?P<pass>[^\']+)\' - Query=(?P<query>.+)'
       - labels: { remote_ip, user }
 
-#─────────── ModSecurity audit (JSON) ───────────
-  - job_name: modsec
-    static_configs:
-      - labels: { job: apache, type: modsec, __path__: /var/log/modsecurity/*audit*.json }
-    pipeline_stages:
-      - json:
-          expressions:
-            txid: transaction.id
-            severity: severity
-            client_ip: transaction.client_ip
-            uri: transaction.request.uri
-      - labels: { txid, severity, client_ip }
-
 #─────────── MySQL slow / error / general ───────────
   - job_name: mysql-error
     static_configs:

--- a/scripts_monitor/antiguo_grafana.json
+++ b/scripts_monitor/antiguo_grafana.json
@@ -914,41 +914,6 @@
       },
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": "auto"
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 50
-      },
-      "id": 11,
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "pluginVersion": "11.6.1",
-      "targets": [
-        {
-          "expr": "{job=\"apache\",type=\"modsec\"}",
-          "refId": "A",
-          "queryType": "range"
-        }
-      ],
-      "title": "Tabla de Alertas ModSecurity (WAF)",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "loki_uid"
-      },
-      "fieldConfig": {
-        "defaults": {
           "color": {
             "mode": "palette-classic"
           },


### PR DESCRIPTION
## Summary
- clean up docker-compose generator to drop unused ModSecurity volume
- remove ModSecurity job from Promtail config
- delete ModSecurity panel from old Grafana dashboard

## Testing
- `bash -n scripts_honeypot/02_gen_compose.sh`
- `bash -n scripts_honeypot/07_promtail.sh`

------
https://chatgpt.com/codex/tasks/task_e_684467e09d5c832a8ee29269f557253e